### PR TITLE
EO-1000 fix latest alpine python

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,6 +45,9 @@ function installAwsCdk(){
 
 function installPipRequirements(){
 	if [ -e "requirements.txt" ]; then
+		echo "Setting up python venv"
+		python -m venv cdkvenv
+		. cdkvenv/bin/activate
 		echo "Install requirements.txt"
 		if [ "${INPUT_DEBUG_LOG}" == "true" ]; then
 			pip install -r requirements.txt


### PR DESCRIPTION
Setting up a venv virtual environment to handle cdk python runs.

This fixes the issue with newest python installs on alpine:
```
error: externally-managed-environment

× This environment is externally managed
```